### PR TITLE
Clarifying IP hint behavior

### DIFF
--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -195,10 +195,10 @@ address, clients MAY choose to opportunistically use the Encrypted Resolver even
 without this certificate check ({{opportunistic}}).
 
 If resolving the name of an Encrypted Resolver from an SVCB record yields an
-IP address that was not presented in the ipv4hint or ipv6hint fields, the
-connection made to that IP address MUST pass the same TLS certificate checks
-before being allowed to replace a previously known and validated IP address for
-the same Encrypted Resolver name.
+IP address that was not presented in the Additional Answers section or ipv4hint
+or ipv6hint fields of the original SVCB query, the connection made to that IP
+address MUST pass the same TLS certificate checks before being allowed to replace
+a previously known and validated IP address for the same Encrypted Resolver name.
 
 ## Opportunistic Discovery {#opportunistic}
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -164,10 +164,13 @@ making other queries. Specifically, the client issues a query for
 If the recursive resolver that receives this query has one or more Designated
 Resolvers, it will return the corresponding SVCB records. When
 responding to these special queries for "dns://resolver.arpa", the SVCB records
-SHOULD contain at least one "ipv4hint" and/or "ipv6hint" keys. These address
-hints indicate the address on which the corresponding Encrypted Resolver can be
-reached and avoid additional DNS lookup for the A and AAAA records of the
-Encrypted Resolver name.
+SHOULD contain at least one "ipv4hint" and/or "ipv6hint" key. This will allow
+the DNS client to make queries over an encrypted connection without waiting to
+resolve the Encrypted Resolver name per {{!I-D.ietf-dnsop-svcb-https}}. If no
+hints are included, clients will be forced to delay use of the Encrypted Resolver
+until an additional DNS lookup for the A and AAAA records can be made to the
+Unencrypted Resolver (or some other resolver the DNS client has been configured
+to use).
 
 ## Authenticated Discovery {#authenticated}
 
@@ -189,6 +192,12 @@ time indicated by the SVCB record's Time to Live (TTL).
 If the Designated Resolver and the Unencrypted Resolver share an IP
 address, clients MAY choose to opportunistically use the Encrypted Resolver even
 without this certificate check ({{opportunistic}}).
+
+If resolving the name of an Encrypted Resolver from an SVCB record yields an
+IP address that was not presented in the ipv4hint or ipv6hint fields, the
+connection made to that IP address MUST pass the same TLS certificate checks
+before being allowed to replace a previously known and validated IP address for
+the same Encrypted Resolver name.
 
 ## Opportunistic Discovery {#opportunistic}
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -133,14 +133,14 @@ The following is an example of an SVCB record describing a DoH server:
 
 ~~~
 _dns.example.net  7200  IN SVCB 1 . (
-     alpn=h2 dohpath=/dns-query{?dns} ipv4hint=x.y.z.w )
+     alpn=h2 dohpath=/dns-query{?dns} )
 ~~~
 
 The following is an example of an SVCB record describing a DoT server:
 
 ~~~
 _dns.example.net  7200  IN SVCB 1 dot.example.net (
-     alpn=dot port=8530 ipv4hint=x.y.z.w )
+     alpn=dot port=8530 )
 ~~~
 
 If multiple Designated Resolvers are available, using one or more
@@ -162,15 +162,16 @@ making other queries. Specifically, the client issues a query for
 {{I-D.ietf-dnsop-svcb-https}}.
 
 If the recursive resolver that receives this query has one or more Designated
-Resolvers, it will return the corresponding SVCB records. When
-responding to these special queries for "dns://resolver.arpa", the SVCB records
-SHOULD contain at least one "ipv4hint" and/or "ipv6hint" key. This will allow
-the DNS client to make queries over an encrypted connection without waiting to
-resolve the Encrypted Resolver name per {{!I-D.ietf-dnsop-svcb-https}}. If no
-hints are included, clients will be forced to delay use of the Encrypted Resolver
-until an additional DNS lookup for the A and AAAA records can be made to the
-Unencrypted Resolver (or some other resolver the DNS client has been configured
-to use).
+Resolvers, it will return the corresponding SVCB records. When responding
+to these special queries for "dns://resolver.arpa", the recursive resolver
+SHOULD include the A and AAAA records for the name of the Designated Resolver
+in the Additional Answers section. This will allow the DNS client to make
+queries over an encrypted connection without waiting to resolve the Encrypted
+Resolver name per {{!I-D.ietf-dnsop-svcb-https}}. If no A/AAAA records or SVCB
+IP address hints are included, clients will be forced to delay use of the
+Encrypted Resolver until an additional DNS lookup for the A and AAAA records
+can be made to the Unencrypted Resolver (or some other resolver the DNS client
+has been configured to use).
 
 ## Authenticated Discovery {#authenticated}
 


### PR DESCRIPTION
Added some text to address #2 and #5 
- reference to SVCB draft with regards to hints
- explained why resolvers should provide hints
- clients MUST subject resolved IP addresses to the same security requirements as other IP address