### PR TITLE
Simplify guidance for forwarders

### DIFF
--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -260,20 +260,19 @@ points.
 
 ## Caching Forwarders
 
-If a caching forwarder consults multiple resolvers, it may be possible for it to
-cache records for the "resolver.arpa" Special Use Domain Name (SUDN) for
-multiple resolvers. This may result in clients sending queries intended to
-discover Designated Resolvers for resolver `foo` and receiving answers
-for resolvers `foo` and `bar`.
+A DNS forwarder SHOULD NOT forward queries for "resolver.arpa" upstream. This is
+to prevent the client from receiving an SVCB record it will fail to authenticate
+because the forwarder's IP address is not in the upstream resolver's Designated
+Resolver's TLS certificate SAN field. A DNS forwarder which already acts as a
+comletely blind forwarder MAY choose to forward these queries when the operator
+expects that this does not apply, either because the operator knows the upstream
+resolver does have the forwarder's IP address or that the operator expects clients
+of the unencrypted resolver to use the SVCB information opportunistically.
 
-A client will successfully reject unintended connections because the
-authenticated discovery will fail or the resolver addresses do not match.
-Clients that attempt unauthenticated connections to resolvers discovered through
-SVCB queries run the risk of connecting to the wrong server in this scenario.
-
-To prevent unnecessary traffic from clients to incorrect resolvers, DNS caching
-resolvers SHOULD NOT cache results for the "resolver.arpa" SUDN other than for
-Designated Resolvers under their control.
+Operators who choose to forward queries for "resolver.arpa" upstream should note
+that client behavior is never guaranteed and use of DDR by a resolver does not
+communicate a requirement for clients to use the SVCB record when it cannot be
+authenticated.
 
 ## Certificate Management
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -264,7 +264,7 @@ A DNS forwarder SHOULD NOT forward queries for "resolver.arpa" upstream. This is
 to prevent the client from receiving an SVCB record it will fail to authenticate
 because the forwarder's IP address is not in the upstream resolver's Designated
 Resolver's TLS certificate SAN field. A DNS forwarder which already acts as a
-comletely blind forwarder MAY choose to forward these queries when the operator
+completely blind forwarder MAY choose to forward these queries when the operator
 expects that this does not apply, either because the operator knows the upstream
 resolver does have the forwarder's IP address in its TLS certificate's SAN field
 or that the operator expects clients of the unencrypted resolver to use the SVCB

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -260,8 +260,8 @@ points.
 
 ## Caching Forwarders
 
-A DNS forwarder SHOULD NOT forward queries for "resolver.arpa" upstream. This is
-to prevent the client from receiving an SVCB record it will fail to authenticate
+A DNS forwarder SHOULD NOT forward queries for "resolver.arpa" upstream. This
+prevents a client from receiving an SVCB record that will fail to authenticate
 because the forwarder's IP address is not in the upstream resolver's Designated
 Resolver's TLS certificate SAN field. A DNS forwarder which already acts as a
 completely blind forwarder MAY choose to forward these queries when the operator

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -266,8 +266,9 @@ because the forwarder's IP address is not in the upstream resolver's Designated
 Resolver's TLS certificate SAN field. A DNS forwarder which already acts as a
 comletely blind forwarder MAY choose to forward these queries when the operator
 expects that this does not apply, either because the operator knows the upstream
-resolver does have the forwarder's IP address or that the operator expects clients
-of the unencrypted resolver to use the SVCB information opportunistically.
+resolver does have the forwarder's IP address in its TLS certificate's SAN field
+or that the operator expects clients of the unencrypted resolver to use the SVCB
+information opportunistically.
 
 Operators who choose to forward queries for "resolver.arpa" upstream should note
 that client behavior is never guaranteed and use of DDR by a resolver does not


### PR DESCRIPTION
Addressing issues #6 and #7 to make the SUDN forwarding a SHOULD NOT unless the operator understands and accepts the implications to authenticated discovery.