### PR TITLE
Cert checks only IP address, clarify server name

### DIFF
--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -126,11 +126,11 @@ DNS resolvers can advertise one or more Designated Resolvers that
 may offer support over encrypted channels and are controlled by the same
 entity.
 
-When a client discovers Designated Resolvers, it learns information
-such as the supported protocols, ports, and server name to use in certificate
-validation. This information is provided in Service Binding (SVCB) records for
-DNS Servers. The formatting of these records, including the DNS-unique parameters
-such as "dohpath", are defined by {{!I-D.ietf-add-svcb-dns}}.
+When a client discovers Designated Resolvers, it learns information such as
+the supported protocols and ports. This information is provided in Service
+Binding (SVCB) records for DNS Servers. The formatting of these records,
+including the DNS-unique parameters such as "dohpath", are defined by
+{{!I-D.ietf-add-svcb-dns}}.
 
 The following is an example of an SVCB record describing a DoH server discovered
 by querying for `_dns.example.net`:
@@ -231,13 +231,10 @@ Authenticated Discovery is a mechanism that allows automatic use of a
 Designated Resolver that supports DNS encryption that performs a TLS handshake.
 
 In order to be considered an authenticated Designated Resolver, the
-TLS certificate presented by the Designated Resolver MUST contain both the domain
-name (from the SVCB answer) and the IP address of the designating Unencrypted
-Resolver within the SubjectAlternativeName certificate field. The client MUST
-check the SubjectAlternativeName field for both the Unencrypted Resolver's IP
-address and the advertised name of the Designated Resolver. If the
-certificate can be validated, the client SHOULD use the discovered Designated
-Resolver for any cases in which it would have otherwise used the
+TLS certificate presented by the Designated Resolver MUST contain the IP address
+of the designating Unencrypted Resolver within the SubjectAlternativeName certificate
+field. If the certificate can be validated, the client SHOULD use the discovered
+Designated Resolver for any cases in which it would have otherwise used the
 Unencrypted Resolver. If the Designated Resolver has a different IP
 address than the Unencrypted Resolver and the TLS certificate does not cover the
 Unencrypted Resolver address, the client MUST NOT automatically use the discovered
@@ -303,9 +300,10 @@ Often, the various supported encrypted DNS protocols will be accessible using
 the same hostname. In the example above, both DoH and DoT use the name
 `resolver.example.com` for their TLS certificates. If a deployment uses a
 different hostname for one protocol, but still wants clients to treat both DNS
-servers as designated, the TLS certificates MUST include both names in the
-SubjectAlternativeName fields. Note that this name verification is not related
-to the DNS resolver that provided the SVCB answer.
+servers as designated, the TLS certificates MUST include the name for which
+the client issued the query in the SubjectAlternativeName field. Note that
+this name verification is not related to the DNS resolver that provided the
+SVCB answer.
 
 For example, being able to discover a Designated Resolver for a known
 Encrypted Resolver is useful when a client has a DoT configuration for
@@ -341,6 +339,20 @@ authenticated.
 Resolver owners that support authenticated discovery will need to list valid
 referring IP addresses in their TLS certificates. This may pose challenges for
 resolvers with a large number of referring IP addresses.
+
+## Server Name Handling
+
+When resolvers are designated using queries for "resolver.arpa" {{bootstrapping}},
+the name of the Designated Resolver is sent via the Server Name Indication
+extension of TLS {{?RFC8446}} for both DoT and DoH, and the host in the URI for
+DoH.
+
+Clients MUST NOT use "resolver.arpa" as the server name. Clients can either use
+IP address of the designating Unencrypted Resolver or the TargetName in the
+ServiceMode SVCB record as the server name.
+
+Designated resolvers that support authenticated discovery MUST accept the IP
+address of designating Unencrypted Resolvers as the server name for DoT and DoH.
 
 # Security Considerations
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -298,7 +298,7 @@ _dns.resolver.example.com.  7200  IN SVCB 1 resolver.example.com. (
 
 Often, the various supported encrypted DNS protocols will be accessible using
 the same hostname. In the example above, both DoH and DoT use the name
-`resolver.example.com` for their TLS certificates. If a deployment uses a
+`resolver.example.com`. If a deployment uses a
 different hostname for one protocol, but still wants clients to treat both DNS
 servers as designated, the TLS certificates MUST include the name for which
 the client issued the query in the SubjectAlternativeName field. Note that

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -296,16 +296,21 @@ _dns.resolver.example.com.  7200  IN SVCB 1 resolver.example.com. (
      alpn=dot )
 ~~~
 
-Often, the various supported encrypted DNS protocols will be accessible using
-the same hostname. In the example above, both DoH and DoT use the name
-`resolver.example.com`. If a deployment uses a
-different hostname for one protocol, but still wants clients to treat both DNS
-servers as designated, the TLS certificates MUST include the name for which
-the client issued the query in the SubjectAlternativeName field. Note that
-this name verification is not related to the DNS resolver that provided the
-SVCB answer.
+Clients MUST validate that for any Encrypted Resolver discovered using a
+known resolver name, the TLS certificate of the resolver contains the
+known name in the SubjectAlternativeName field. In the example above,
+this means that both servers need to have certificates that cover
+the name `resolver.example.com`. Often, the various supported encrypted
+DNS protocols will be specified such that the SVCB TargetName matches the
+known name, as is true in the example above. However, even when the
+TargetName is different (for example, if the DoH server had a TargetName of
+`doh.example.com`), the clients still check for the original known resolver
+name in the certificate.
 
-For example, being able to discover a Designated Resolver for a known
+Note that this resolver validation is not related to the DNS resolver that
+provided the SVCB answer.
+
+As another example, being able to discover a Designated Resolver for a known
 Encrypted Resolver is useful when a client has a DoT configuration for
 `foo.resolver.example.com` but is on a network that blocks DoT traffic. The
 client can still send a query to any other accessible resolver (either the local
@@ -343,14 +348,16 @@ resolvers with a large number of referring IP addresses.
 ## Server Name Handling
 
 Clients MUST NOT use "resolver.arpa" as the server name either in the TLS
-Server Name Indication in TLS ({{?RFC8446}}) for DoT or DoH; or in the URI host
-for DoH requests.
+Server Name Indication in TLS ({{?RFC8446}}) for DoT or DoH connections,
+or in the URI host for DoH requests.
 
-Designated DoH resolvers that support authenticated discovery MUST accept
-both of the following as the URI host in requests:
+Designated DoH resolvers that support authenticated discovery for clients
+that only know an IP address MUST accept both of the following as the
+URI host in requests:
 
 - the IP address of designating Unencrypted Resolver
-- the TargetName in the ServiceMode SVCB record
+- the TargetName in the ServiceMode SVCB record, which is the
+hostname for which the client looked up address (A and AAAA) records
 
 # Security Considerations
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -298,7 +298,7 @@ _dns.resolver.example.com.  7200  IN SVCB 1 resolver.example.com. (
 
 Clients MUST validate that for any Encrypted Resolver discovered using a
 known resolver name, the TLS certificate of the resolver contains the
-known name in the SubjectAlternativeName field. In the example above,
+known name in a subjectAltName extension. In the example above,
 this means that both servers need to have certificates that cover
 the name `resolver.example.com`. Often, the various supported encrypted
 DNS protocols will be specified such that the SVCB TargetName matches the

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -77,9 +77,10 @@ resolvers using DNS server Service Binding (SVCB, {{I-D.ietf-dnsop-svcb-https}})
 records:
 
 1. When only an IP address of an Unencrypted Resolver is known, the client
-queries a special use domain name to discover DNS SVCB records associated with
-one or more Encrypted Resolvers the Unencrypted Resolver has designated for use
-when support for DNS encryption is requested ({{bootstrapping}}). 
+queries a special use domain name (SUDN) {{!RFC6761}} to discover DNS SVCB
+records associated with one or more Encrypted Resolvers the Unencrypted
+Resolver has designated for use when support for DNS encryption is
+requested ({{bootstrapping}}). 
 
 2. When the hostname of an Encrypted Resolver is known, the client requests
 details by sending a query for a DNS SVCB record. This can be used to discover
@@ -378,7 +379,8 @@ to take into account the attack scenarios detailed here.
 
 ## Special Use Domain Name "resolver.arpa"
 
-This document calls for the creation of the "resolver.arpa" SUDN. This will
+This document calls for the addition of "resolver.arpa" to the Special-Use
+Domain Names (SUDN) registry established by {{!RFC6761}}. This will
 allow resolvers to respond to queries directed at themselves rather than a
 specific domain name. While this document uses "resolver.arpa" to return SVCB
 records indicating designated encrypted capability, the name is generic enough

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -342,17 +342,14 @@ resolvers with a large number of referring IP addresses.
 
 ## Server Name Handling
 
-When resolvers are designated using queries for "resolver.arpa" {{bootstrapping}},
-the name of the Designated Resolver is sent via the Server Name Indication
-extension of TLS {{?RFC8446}} for both DoT and DoH, and the host in the URI for
-DoH.
+Clients MUST NOT use "resolver.arpa" as the server name either in the TLS
+Server Name Indication in TLS ({{?RFC8446}}) for DoT or DoH; or in the URI host
+for DoH requests.
 
-Clients MUST NOT use "resolver.arpa" as the server name. Clients can either use
-IP address of the designating Unencrypted Resolver or the TargetName in the
-ServiceMode SVCB record as the server name.
-
-Designated resolvers that support authenticated discovery MUST accept the IP
-address of designating Unencrypted Resolvers as the server name for DoT and DoH.
+Designated DoH resolvers that support authenticated discovery MUST accept the IP
+address of designating Unencrypted Resolvers as the URI host. Clients MAY use
+either the IP address or the TargetName in the ServiceMode SVCB record as the
+URI host.
 
 # Security Considerations
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -346,10 +346,11 @@ Clients MUST NOT use "resolver.arpa" as the server name either in the TLS
 Server Name Indication in TLS ({{?RFC8446}}) for DoT or DoH; or in the URI host
 for DoH requests.
 
-Designated DoH resolvers that support authenticated discovery MUST accept the IP
-address of designating Unencrypted Resolvers as the URI host. Clients MAY use
-either the IP address or the TargetName in the ServiceMode SVCB record as the
-URI host.
+Designated DoH resolvers that support authenticated discovery MUST accept
+both of the following as the URI host in requests:
+
+- the IP address of designating Unencrypted Resolver
+- the TargetName in the ServiceMode SVCB record
 
 # Security Considerations
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -349,17 +349,16 @@ resolvers with a large number of referring IP addresses.
 ## Server Name Handling
 
 Clients MUST NOT use "resolver.arpa" as the server name either in the TLS
-Server Name Indication in TLS ({{?RFC8446}}) for DoT or DoH connections,
+Server Name Indication (SNI) ({{?RFC8446}}) for DoT or DoH connections,
 or in the URI host for DoH requests.
 
-Designated DoH resolvers that support Verified Discovery for clients
-that only know an IP address MUST accept both of the following as the
-URI host in requests:
+When performing discovery using resolver IP addresses, clients MUST
+use the IP address as the URI host for DoH requests.
 
-- the IP address of designating Unencrypted Resolver.
-- the TargetName in the ServiceMode SVCB record, which is the
-hostname that maps to the address (A and AAAA) records used to
-connect to the Encrypted Resolver.
+Note that since IP addresses are not supported by default in the TLS SNI,
+resolvers that support discovery using IP addresses will need to be
+configured to present the appropriate TLS certificate when no SNI is present
+for both DoT and DoH. 
 
 # Security Considerations
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -355,9 +355,10 @@ Designated DoH resolvers that support authenticated discovery for clients
 that only know an IP address MUST accept both of the following as the
 URI host in requests:
 
-- the IP address of designating Unencrypted Resolver
+- the IP address of designating Unencrypted Resolver.
 - the TargetName in the ServiceMode SVCB record, which is the
-hostname for which the client looked up address (A and AAAA) records
+hostname that maps to the address (A and AAAA) records used to
+connect to the Encrypted Resolver.
 
 # Security Considerations
 


### PR DESCRIPTION
Closes #41

- Remove text about extra cert checks, just focus on the IP address
- Add considerations about server name handling. Server must accept IP address for SNI and URI host. Clients must not use resolver.arpa for this value. Clients can either send the IP address or the ServiceMode TargetName