### PR TITLE
Change the introductory text to only talk about the designated IP.

### DIFF
--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -91,8 +91,8 @@ Both of these approaches allow clients to confirm that a discovered Encrypted
 Resolver is designated by the originally provisioned resolver. "Designated" in
 this context means that the resolvers are operated by the same entity or
 cooperating entities; for example, the resolvers are accessible on the same
-IP address, or there is a certificate that claims ownership over the designated
-resolver IP address (regardless of what IP the designated resolver is on).
+IP address, or there is a certificate that claims ownership over the original
+designating resolver.
 
 ## Specification of Requirements
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -91,7 +91,8 @@ Both of these approaches allow clients to confirm that a discovered Encrypted
 Resolver is designated by the originally provisioned resolver. "Designated" in
 this context means that the resolvers are operated by the same entity or
 cooperating entities; for example, the resolvers are accessible on the same
-IP address, or there is a certificate that claims ownership over both resolvers.
+IP address, or there is a certificate that claims ownership over the designated
+resolver IP address (regardless of what IP the designated resolver is on).
 
 ## Specification of Requirements
 

--- a/draft-ietf-add-ddr.md
+++ b/draft-ietf-add-ddr.md
@@ -91,8 +91,8 @@ Both of these approaches allow clients to confirm that a discovered Encrypted
 Resolver is designated by the originally provisioned resolver. "Designated" in
 this context means that the resolvers are operated by the same entity or
 cooperating entities; for example, the resolvers are accessible on the same
-IP address, or there is a certificate that claims ownership over the original
-designating resolver.
+IP address, or there is a certificate that claims ownership over the 
+IP address for the original designating resolver.
 
 ## Specification of Requirements
 


### PR DESCRIPTION
We only require you to check the designated resolver IP so this text
is now incorrect.